### PR TITLE
Fix various typos

### DIFF
--- a/01-basic-extension/README.md
+++ b/01-basic-extension/README.md
@@ -9,7 +9,7 @@ rebuild / reinitialize cluster. If you can, start experimenting with
 an extension instead of hacking on the core right away, it will make
 your life much easier.
 
-Hint: Start by looking for extensions that alredy do something similar,
+Hint: Start by looking for extensions that already do something similar,
 and use them as a starting point.
 
 Steps:

--- a/01-basic-extension/extension/hacking.control
+++ b/01-basic-extension/extension/hacking.control
@@ -1,4 +1,4 @@
 # hacking intro extension
-comment = 'skeleton of a minimal extensio'
+comment = 'skeleton of a minimal extension'
 default_version = '1.0.0'
 relocatable = true

--- a/02-sql-regression-test/README.md
+++ b/02-sql-regression-test/README.md
@@ -4,7 +4,7 @@ Exercise: SQL regression test
 This exercise adds a trivial SQL regression test, to do simple testing
 of the extension code.
 
-SQL tests simply define (a) file with SQL queries/commandss, executed
+SQL tests simply define (a) file with SQL queries/commands, executed
 in a single session/connection, and (b) another file with expected
 output. This is a great way to do basic testing of changes that affect
 results of SQL queries etc.

--- a/03-tap-regression-test/README.md
+++ b/03-tap-regression-test/README.md
@@ -11,16 +11,16 @@ programming and thus more complex workflows, multiple instances,
 restarts, etc.
 
 We'll create a minimum TAP test, that initializes an instance with a
-custom configuration, checks a result of a result, restarts the
+custom configuration, checks a result of the test, restarts the
 instance and checks the log. And then shuts the instance.
 
 Steps:
 
-1. Go to the "extension" directory, create an empty file `t/001_basic.sql`
+1. Go to the "extension" directory, create an empty file `t/001_basic.pl`
    and run `make installcheck`. It should try to run the test and fail,
    complaining about the file not defining any tests.
 
-2. Add this minimal skeleton of a TAP test to the file. It create an
+2. Add this minimal skeleton of a TAP test to the file. It creates an
    instance, starts it, stops it, and finishes testing.
 
 ```

--- a/04-basic-logging/README.md
+++ b/04-basic-logging/README.md
@@ -54,7 +54,7 @@ Steps:
 
    It's defined in the same `elog.h` header, and it supports "context"
    in  the form of `errcode`, `errmsg`, `errdetail`, `errhint` etc.
-   It's porobably easier to look for places that emit similar message
+   It's probably easier to look for places that emit similar message
    (e.g. check privileges, data types, ...).
 
    The errcodes are defined in the SQL standard and you may find a list
@@ -63,4 +63,4 @@ Steps:
 7. Modify the extension to use the `ereport` interface. Add `errhint`
    and `errdetail` with additional details that should be logged.
 
-8. Try runinng the tests using `make installcheck` again, fix them.
+8. Try running the tests using `make installcheck` again, fix them.

--- a/05-using-asserts/README.md
+++ b/05-using-asserts/README.md
@@ -5,7 +5,7 @@ Asserts are a convenient way to enforce conditions (invariants) during
 development. This should prevent "can't happen" cases and verify "must
 happen" cases.
 
-This is an "extension" of the asserts provided by standad library,
+This is an "extension" of the asserts provided by standard library,
 integrated into the Postgres configure / build system. In production
 builds asserts are disabled.
 
@@ -30,7 +30,7 @@ Steps:
    ```
 
    And try running the tests again. It should fail. (The `CPPFLAGS` is
-   optional - it disables optimizations, which makes it easiert to
+   optional - it disables optimizations, which makes it easier to
    analyze core dumps.)
 
 3. It's often useful to investigate why/where an ABORT happened, which
@@ -81,7 +81,7 @@ Steps:
    With this in place (and instance restarted), run `installcheck`
    again. You should get a core file.
 
-6. Now inspect the core file using `gdb` by speficying the paths to the
+6. Now inspect the core file using `gdb` by specifying the paths to the
    postgres binary and the core file.
 
    ```

--- a/07-varlena-data-types/README.md
+++ b/07-varlena-data-types/README.md
@@ -64,7 +64,7 @@ Steps:
    PG_RETURN_CSTRING(msg_str);
    ```
 
-   Similar to `PG_GETARG_*` macros, you can chech other variants of
+   Similar to `PG_GETARG_*` macros, you can check other variants of
    `PG_RETURN_*` macros. 
 
 

--- a/08-toasted-values/README.md
+++ b/08-toasted-values/README.md
@@ -37,7 +37,7 @@ Steps:
    TOAST have an associated TOAST relation.
 
    ```
-   SELECT toastrelid::regclass FROM pg_class WHERE relname = 't';
+   SELECT reltoastrelid::regclass FROM pg_class WHERE relname = 't';
    
    SELECT * FROM pg_toast.pg_toast_24801;
    ```

--- a/09-memory-contexts/README.md
+++ b/09-memory-contexts/README.md
@@ -6,7 +6,7 @@ to track exactly what you allocated and then free it at the appropriate
 time. It's easy to end up with either memory leaks, double-free or
 use-after-free bugs etc.
 
-This is especially true true for systems where the different pieces of
+This is especially true for systems where the different pieces of
 memory have vastly different life spans. Some memory needs to exist for
 as long as the backend is running, other pieces are per transaction,
 query, operation, row, ...


### PR DESCRIPTION
Please note that this commit does not update the PDF file, as I do not have `mdpdf` installed.